### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ type: Opaque
 ```
 
 ### Installation
+#### Prebuilt
+Download the appropriate binary for your OS from the [releases section](https://github.com/ashleyschuett/kubernetes-secret-decode/releases), make it executable and add it to your path.
 
+#### Compile From Source
 These instructions assume you have go installed and a `$GOPATH` set.
 The binary needs to be installed somewhere in your `$PATH`.
 The binary also needs to be named either `kubectl-ksd` or `kubectl-kubernetes-secret-decode`
@@ -50,11 +53,6 @@ The binary also needs to be named either `kubectl-ksd` or `kubectl-kubernetes-se
 For easy install running the following:
 ```
 make install
-```
-
-Another option is to download the binary and add it to your path
-```
-curl -LO https://github.com/ashleyschuett/kubernetes-secret-decode/releases/download/v3.0.0/kubectl-ksd && chmod +x ksd && sudo mv ksd /usr/local/bin
 ```
 
 ### Usage


### PR DESCRIPTION
Current link is broken and returns a 404. I figure the prebuilt binaries are easier to use so I've moved that to the top of the Installation section.